### PR TITLE
Replaced footer contact link to contact the training team.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,7 +73,8 @@ repository: <USERNAME>/<PROJECT>
 # Email address, no mailto:
 # (Don't change this -- the contact address for your workshop will be set
 # in the index.md file)
-email: "team@carpentries.org"
+email: "training@esciencecenter.nl"
+email_carpentries: "team@carpentries.org"
 
 # Sites.
 amy_site: "https://amy.carpentries.org/"

--- a/_includes/workshop_footer.html
+++ b/_includes/workshop_footer.html
@@ -15,12 +15,20 @@
 	<a href="{{ site.lc_site }}">Library Carpentry</a>
 	{% elsif site.carpentry == "cp" %}
 	<a href="{{ site.carpentries_site }}">The Carpentries</a>
+        {% elsif site.carpentry == "ds" %}
+        <a href="{{ site.carpentries_site }}">The Carpentries</a>
+        {% elsif site.carpentry == "cr" %}
+        <a href="{{ site.carpentries_site }}">The Carpentries</a>
 	{% endif %}
       </h4>
     </div>
     <div class="col-md-6" align="right">
       <h4>
-	<a href="mailto:{{ site.email }}">Contact The Carpentries</a>
+        {% if site.carpentry == "ds" or site.carpentry == "cr" %}
+        <a href="mailto:{{ site.email }}">Contact The Training Team</a>
+        {% else %}
+	<a href="mailto:{{ site.email_carpentries }}">Contact The Carpentries</a>
+        {% endif %}
       </h4>
     </div>
   </div>


### PR DESCRIPTION
Resolves issue #7

Note that the footer also contains a Copyright notice. The link in this notice changes based on the carpentry and doesn't have a default.
For the DC (CR) carpentries, I've copied the carpentries notice (from the CP setting), which links to https://carpentries.org/ Is this still correct?