### PR TITLE
Navbar license links to general eScience Academy .io license page.

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -91,7 +91,7 @@
 	{% endif %}
 
 	{% comment %} Always show license. {% endcomment %}
-        <li><a href="{{ relative_root_path }}{% link LICENSE.md %}">License</a></li>
+        <li><a href="https://escience-academy.github.io/license">License</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Resolves issue #47 

License page still has to be adjusted on the https://escience-academy.github.io/license side.